### PR TITLE
Add content refresh button to system shade

### DIFF
--- a/server/app/database.py
+++ b/server/app/database.py
@@ -270,6 +270,14 @@ class Database:
                 "expired": datetime.now(timezone.utc) > expires_at,
             }
 
+    async def invalidate_all_cached_content(self):
+        """Expire all cached dynamic content so the next request triggers a fresh resolve."""
+        await self.db.execute(
+            "UPDATE dynamic_content SET expires_at = ?",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        await self.db.commit()
+
     async def set_cached_content(self, content_key: str, text: str,
                                  etag: str, ttl_seconds: int):
         expires_at = datetime.now(timezone.utc).isoformat()

--- a/server/app/routes/dynamic.py
+++ b/server/app/routes/dynamic.py
@@ -87,6 +87,12 @@ def create_router(db: Database, datasources: DataSourceRegistry,
             headers={"ETag": f'"{etag}"'},
         )
 
+    @router.post("/refresh")
+    async def refresh_content():
+        """Invalidate all cached dynamic content, forcing fresh resolution on next request."""
+        await db.invalidate_all_cached_content()
+        return {"status": "ok"}
+
     return router
 
 

--- a/src/application/interface/components/settings/ContentRefreshPanel.h
+++ b/src/application/interface/components/settings/ContentRefreshPanel.h
@@ -1,0 +1,112 @@
+#ifndef _CONTENT_REFRESH_PANEL_H_
+#define _CONTENT_REFRESH_PANEL_H_
+
+#include "application/Application.h"
+#include "application/interface/components/types/StatefulComponent.h"
+#include "application/interface/components/input/Button.h"
+#include "config/NetworkConfig.h"
+#include "events/types/TouchEvent.h"
+
+class ContentRefreshPanel : public StatefulComponent {
+  enum class Status { Idle, Refreshing, Done, Error };
+  Status status = Status::Idle;
+  Timer debounce{500};
+
+  lv_obj_t *statusLabel = nullptr;
+  lv_obj_t *actionLabel = nullptr;
+
+  void doRefresh() {
+    if (app == nullptr) return;
+    INetwork &net = app->device()->network();
+    if (!net.isConnected()) {
+      status = Status::Error;
+      update();
+      return;
+    }
+
+    status = Status::Refreshing;
+    update();
+    lv_refr_now(NULL);
+
+    // 1. Invalidate server-side dynamic content cache
+    char url[128];
+    snprintf(url, sizeof(url), "%s/api/dynamic/refresh", OTA_UPDATE_URL);
+    HttpResponse resp = net.post(url, "{}", "application/json");
+
+    // 2. Re-fetch the UI manifest
+    snprintf(url, sizeof(url), "%s/api/ui/screens?board=%s",
+             OTA_UPDATE_URL, BOARD_ID);
+    HttpResponse manifestResp = net.get(url);
+    if (manifestResp.statusCode == 200) {
+      app->userScreenManager().loadManifest(manifestResp.body.c_str());
+    }
+
+    status = (resp.statusCode == 200) ? Status::Done : Status::Error;
+    update();
+  }
+
+public:
+  void createWidgets(lv_obj_t *parent) override {
+    lvObj = lv_obj_create(parent);
+    lv_obj_remove_style_all(lvObj);
+    lv_obj_set_size(lvObj, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(lvObj, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(lvObj, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_all(lvObj, 8, 0);
+    lv_obj_set_style_pad_row(lvObj, 4, 0);
+
+    statusLabel = lv_label_create(lvObj);
+    lv_obj_set_style_text_font(statusLabel, &lv_font_montserrat_12, 0);
+
+    actionLabel = lv_label_create(lvObj);
+    lv_obj_set_style_text_font(actionLabel, &lv_font_montserrat_14, 0);
+
+    update();
+  }
+
+  void update() override {
+    if (actionLabel == nullptr) return;
+
+    switch (status) {
+    case Status::Idle:
+      lv_label_set_text(statusLabel, "");
+      lv_label_set_text(actionLabel, LV_SYMBOL_REFRESH " Refresh Content");
+      lv_obj_set_style_text_color(actionLabel, lv_color_hex(0x3B82F6), 0);
+      break;
+    case Status::Refreshing:
+      lv_label_set_text(statusLabel, "Refreshing...");
+      lv_obj_set_style_text_color(statusLabel, lv_color_hex(0xF59E0B), 0);
+      lv_label_set_text(actionLabel, "");
+      break;
+    case Status::Done:
+      lv_label_set_text(statusLabel, "Content refreshed");
+      lv_obj_set_style_text_color(statusLabel, lv_color_hex(0x22C55E), 0);
+      lv_label_set_text(actionLabel, LV_SYMBOL_REFRESH " Refresh again");
+      lv_obj_set_style_text_color(actionLabel, lv_color_hex(0x3B82F6), 0);
+      break;
+    case Status::Error:
+      lv_label_set_text(statusLabel, "Refresh failed");
+      lv_obj_set_style_text_color(statusLabel, lv_color_hex(0xEF4444), 0);
+      lv_label_set_text(actionLabel, LV_SYMBOL_REFRESH " Retry");
+      lv_obj_set_style_text_color(actionLabel, lv_color_hex(0x3B82F6), 0);
+      break;
+    }
+  }
+
+  void handleEvent(InputEvent &event) override {
+    if (event.inputType != InputType::TouchInput) return;
+    TouchEvent &te = static_cast<TouchEvent &>(event);
+    if (te.type != TouchType::TapType) return;
+    if (app == nullptr || lvObj == nullptr) return;
+
+    TapTouchEvent &tap = static_cast<TapTouchEvent &>(event);
+    if (!Button::hitTest(lvObj, tap.location.x, tap.location.y)) return;
+    if (debounce.running()) return;
+    debounce.start();
+
+    doRefresh();
+  }
+};
+
+#endif // _CONTENT_REFRESH_PANEL_H_

--- a/src/config/screens/Screens.cpp
+++ b/src/config/screens/Screens.cpp
@@ -11,6 +11,7 @@
 #include "application/interface/components/core/Text.h"
 #include "application/interface/components/settings/OTAUpdatePanel.h"
 #include "application/interface/components/settings/DisplayInfoPanel.h"
+#include "application/interface/components/settings/ContentRefreshPanel.h"
 #include "application/interface/components/settings/RotationToggle.h"
 
 // ---------------------------------------------------------------------------
@@ -48,6 +49,9 @@ RenderableComponent SystemShadeState() {
         ),
         E(TitledCard, {.icon = LV_SYMBOL_WIFI, .title = "WiFi"},
           E(Text, {.color = CLR_GREEN}, "Connected")
+        ),
+        E(Card, {},
+          E(ContentRefreshPanel)
         ),
         E(Card, {},
           E(DisplayInfoPanel),


### PR DESCRIPTION
## Summary
- Adds a **Refresh Content** button to the system shade that invalidates server-side dynamic content caches (`POST /api/dynamic/refresh`) and re-fetches the UI manifest
- When the user navigates back to their dashboard, all DynamicText/LLMText components are recreated with fresh server data
- Follows the same UI patterns as OTAUpdatePanel (status feedback: refreshing/done/error)

## Test plan
- [ ] Open system shade (swipe down), verify the refresh button card appears between WiFi and Display cards
- [ ] Tap "Refresh Content" — verify it shows "Refreshing..." then "Content refreshed"
- [ ] Swipe back to dashboard — verify dynamic content loads fresh data
- [ ] Test with no network — verify "Refresh failed" error state
- [ ] Verify `POST /api/dynamic/refresh` invalidates LLM cache entries in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)