### PR TITLE
Redesign UI builder with industrial enterprise theme

### DIFF
--- a/server/web/index.html
+++ b/server/web/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>round_touch Editor</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
   </head>
   <body>

--- a/server/web/src/App.css
+++ b/server/web/src/App.css
@@ -1,19 +1,55 @@
+/* ============================================================
+   round_touch Editor — Industrial Enterprise Theme
+   ============================================================ */
+
 :root {
-  --bg: #09090b;
-  --bg-surface: #18181b;
-  --bg-hover: #27272a;
-  --bg-selected: #3f3f46;
-  --border: #27272a;
-  --text: #fafafa;
-  --text-muted: #a1a1aa;
-  --text-dim: #71717a;
-  --accent: #3b82f6;
-  --accent-hover: #2563eb;
-  --danger: #ef4444;
-  --success: #22c55e;
-  --radius: 8px;
-  --gap: 8px;
+  /* Backgrounds — deep layered charcoal */
+  --bg-base: #0A0A0C;
+  --bg-surface: #111113;
+  --bg-elevated: #18181B;
+  --bg-hover: #1E1E22;
+  --bg-active: #26262B;
+  --bg-input: #0D0D0F;
+
+  /* Borders */
+  --border-subtle: #1C1C20;
+  --border-default: #27272B;
+  --border-strong: #333338;
+
+  /* Text */
+  --text-primary: #EDEDF0;
+  --text-secondary: #8B8B93;
+  --text-tertiary: #5A5A63;
+
+  /* Accent — warm amber (industrial warning-light feel) */
+  --accent: #E8893C;
+  --accent-hover: #D47B32;
+  --accent-muted: #B06A2A;
+  --accent-subtle: rgba(232, 137, 60, 0.10);
+  --accent-glow: rgba(232, 137, 60, 0.20);
+
+  /* Status */
+  --danger: #E5534B;
+  --danger-subtle: rgba(229, 83, 75, 0.10);
+  --success: #3FB950;
+  --success-subtle: rgba(63, 185, 80, 0.10);
+  --info: #58A6FF;
+
+  /* Sizing */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* Typography */
+  --font-sans: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
+
+  /* Transitions */
+  --transition-fast: 120ms ease;
+  --transition-normal: 200ms ease;
 }
+
+/* ---- Reset ---- */
 
 * {
   box-sizing: border-box;
@@ -23,11 +59,43 @@
 
 html, body, #root {
   height: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: 14px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
+
+::selection {
+  background: var(--accent-glow);
+  color: var(--text-primary);
+}
+
+/* ---- Scrollbars ---- */
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
+}
+
+/* ============================================================
+   App Shell
+   ============================================================ */
 
 .app {
   display: flex;
@@ -35,86 +103,284 @@ html, body, #root {
   height: 100%;
 }
 
-/* Header */
+/* ============================================================
+   Header
+   ============================================================ */
+
 .header {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
+  padding: 0 16px;
+  height: 48px;
+  border-bottom: 1px solid var(--border-default);
   background: var(--bg-surface);
   flex-shrink: 0;
 }
 
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 12px;
+}
+
+.header-logo {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent-glow), 0 0 2px var(--accent);
+  flex-shrink: 0;
+}
+
 .header-title {
+  font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 15px;
-  margin-right: auto;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+  color: var(--text-primary);
 }
 
-.header select {
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 4px 8px;
-  font-size: 13px;
+.header-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border-default);
+  flex-shrink: 0;
 }
 
-/* Buttons */
-button {
-  background: var(--bg-hover);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 4px 12px;
-  font-size: 13px;
+.header-spacer {
+  flex: 1;
+}
+
+/* ---- Board selector ---- */
+
+.board-select-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.board-select-wrapper i {
+  position: absolute;
+  left: 10px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.board-select {
+  appearance: none;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 6px 32px 6px 30px;
+  font-size: 12px;
+  font-family: var(--font-mono);
   cursor: pointer;
-  font-family: inherit;
+  transition: border-color var(--transition-fast);
+  min-width: 180px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%235A5A63' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+
+.board-select:hover {
+  border-color: var(--border-strong);
+}
+
+.board-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-subtle);
+}
+
+/* ---- Mode toggle (segmented control) ---- */
+
+.mode-toggle {
+  display: flex;
+  background: var(--bg-input);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  gap: 1px;
+}
+
+.mode-toggle-btn {
+  background: transparent;
+  color: var(--text-tertiary);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 4px 14px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.mode-toggle-btn:hover {
+  color: var(--text-secondary);
+}
+
+.mode-toggle-btn.active {
+  background: var(--bg-active);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+/* ---- Save button ---- */
+
+.save-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--accent);
+  color: #0A0A0C;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  letter-spacing: 0.3px;
+}
+
+.save-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.save-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.save-btn i {
+  font-size: 12px;
+}
+
+/* ---- Dirty indicator ---- */
+
+.dirty-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent-glow);
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   Generic button styles
+   ============================================================ */
+
+button {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 button:hover {
-  background: var(--bg-selected);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 
 button:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
+}
+
+button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-subtle);
 }
 
 button.primary {
   background: var(--accent);
   border-color: var(--accent);
-  color: white;
+  color: #0A0A0C;
+  font-weight: 600;
 }
 
 button.primary:hover {
   background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
 button.danger {
   color: var(--danger);
 }
 
-button.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: white;
+button.danger:hover {
+  background: var(--danger-subtle);
+  border-color: var(--danger);
 }
 
-button.small {
-  padding: 2px 6px;
-  font-size: 12px;
+button.ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-tertiary);
+  padding: 3px 6px;
 }
 
-/* Tab manager */
+button.ghost:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: transparent;
+}
+
+/* Icon-only button (square) */
+button.icon-btn {
+  padding: 4px;
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  font-size: 11px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-tertiary);
+}
+
+button.icon-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: transparent;
+}
+
+button.icon-btn.danger:hover {
+  background: var(--danger-subtle);
+  color: var(--danger);
+}
+
+/* ============================================================
+   Tab Manager
+   ============================================================ */
+
 .tab-manager {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   padding: 6px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-base);
   flex-shrink: 0;
   overflow-x: auto;
 }
@@ -122,40 +388,80 @@ button.small {
 .tab-item {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 12px;
-  border-radius: var(--radius);
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12px;
+  font-family: var(--font-sans);
+  font-weight: 500;
   white-space: nowrap;
   border: 1px solid transparent;
+  color: var(--text-tertiary);
+  transition: all var(--transition-fast);
+  position: relative;
 }
 
 .tab-item:hover {
   background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 .tab-item.active {
-  background: var(--bg-selected);
-  border-color: var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border-color: var(--border-default);
 }
 
-.tab-item.default {
-  border-color: var(--accent);
+.tab-item.default::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
 }
 
 .tab-icon {
   font-family: FontAwesome;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .tab-actions {
   display: flex;
-  gap: 2px;
+  gap: 1px;
   margin-left: 4px;
 }
 
-/* Main content */
+.tab-add-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-size: 14px;
+  margin-left: 4px;
+}
+
+.tab-add-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+/* ============================================================
+   Main Layout
+   ============================================================ */
+
 .editor-main {
   display: flex;
   flex: 1;
@@ -164,21 +470,71 @@ button.small {
 
 .panel {
   overflow-y: auto;
-  padding: 12px;
+  display: flex;
+  flex-direction: column;
 }
 
 .panel-left {
-  width: 40%;
-  min-width: 280px;
-  border-right: 1px solid var(--border);
+  width: 320px;
+  min-width: 260px;
+  border-right: 1px solid var(--border-default);
+  background: var(--bg-surface);
+}
+
+.panel-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 20px;
+  min-width: 200px;
+  background: var(--bg-base);
+  border-right: 1px solid var(--border-default);
 }
 
 .panel-right {
   flex: 1;
   min-width: 280px;
+  background: var(--bg-surface);
 }
 
-/* Component tree */
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  background: var(--bg-surface);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.panel-header-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--text-tertiary);
+}
+
+.panel-header-label i {
+  margin-right: 4px;
+  font-size: 10px;
+}
+
+.panel-content {
+  padding: 10px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* ============================================================
+   Component Tree
+   ============================================================ */
+
 .tree-node {
   user-select: none;
 }
@@ -187,10 +543,12 @@ button.small {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 4px;
-  border-radius: 4px;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12px;
+  transition: background var(--transition-fast);
+  border: 1px solid transparent;
 }
 
 .tree-node-header:hover {
@@ -198,35 +556,48 @@ button.small {
 }
 
 .tree-node-header.selected {
-  background: var(--bg-selected);
+  background: var(--accent-subtle);
+  border-color: rgba(232, 137, 60, 0.20);
 }
 
 .tree-node-toggle {
   width: 16px;
   text-align: center;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   flex-shrink: 0;
+  font-size: 10px;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.tree-node-toggle:hover {
+  color: var(--text-secondary);
 }
 
 .tree-node-type {
+  font-family: var(--font-mono);
   font-weight: 500;
+  font-size: 12px;
   color: var(--accent);
 }
 
 .tree-node-summary {
-  color: var(--text-muted);
-  margin-left: 4px;
+  color: var(--text-tertiary);
+  margin-left: 6px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 11px;
+  font-style: italic;
 }
 
 .tree-node-actions {
   display: flex;
-  gap: 2px;
+  gap: 1px;
   margin-left: auto;
   flex-shrink: 0;
   opacity: 0;
+  transition: opacity var(--transition-fast);
 }
 
 .tree-node-header:hover .tree-node-actions {
@@ -234,107 +605,182 @@ button.small {
 }
 
 .tree-node-children {
-  padding-left: 16px;
+  padding-left: 14px;
+  margin-left: 7px;
+  border-left: 1px solid var(--border-subtle);
 }
 
 .tree-add-child {
   padding: 4px 4px 4px 20px;
 }
 
-/* Prop editor */
+/* ============================================================
+   Property Editor
+   ============================================================ */
+
 .prop-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
-.prop-editor h3 {
-  font-size: 15px;
+.prop-editor-title {
+  font-family: var(--font-mono);
+  font-size: 14px;
   font-weight: 600;
-  color: var(--text);
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border);
+  color: var(--accent);
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prop-editor-title i {
+  font-size: 12px;
+  color: var(--text-tertiary);
 }
 
 .prop-editor-section {
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--text-dim);
-  letter-spacing: 0.5px;
-  margin-top: 8px;
+  color: var(--text-tertiary);
+  letter-spacing: 1px;
+  margin-top: 6px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
+
+.prop-editor-section::before {
+  content: "";
+  width: 3px;
+  height: 10px;
+  background: var(--accent-muted);
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+/* ---- Form fields ---- */
 
 .prop-field {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 
 .prop-field label {
-  font-size: 12px;
-  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
 }
 
 .prop-field input,
 .prop-field select {
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 4px 8px;
-  font-size: 13px;
-  font-family: inherit;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .prop-field input:focus,
 .prop-field select:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-subtle);
 }
 
-/* Color picker */
+.prop-field input::placeholder {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.prop-field select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%235A5A63' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  padding-right: 28px;
+  cursor: pointer;
+}
+
+.prop-field input[type="number"] {
+  font-variant-numeric: tabular-nums;
+}
+
+.prop-no-props {
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-style: italic;
+  padding: 8px 0;
+}
+
+/* ============================================================
+   Color Picker
+   ============================================================ */
+
 .color-input-row {
   display: flex;
-  gap: 4px;
+  gap: 6px;
   align-items: center;
 }
 
 .color-input-row input[type="color"] {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  background: none;
+  background: var(--bg-input);
+  transition: border-color var(--transition-fast);
+}
+
+.color-input-row input[type="color"]:hover {
+  border-color: var(--border-strong);
 }
 
 .color-presets {
   display: flex;
   flex-wrap: wrap;
-  gap: 3px;
-  margin-top: 4px;
+  gap: 4px;
+  margin-top: 6px;
 }
 
 .color-swatch {
-  width: 20px;
-  height: 20px;
-  border-radius: 3px;
-  border: 1px solid var(--border);
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  border: 2px solid transparent;
   cursor: pointer;
+  transition: all var(--transition-fast);
+  outline: 1px solid var(--border-subtle);
 }
 
 .color-swatch:hover {
-  border-color: var(--text-muted);
+  outline-color: var(--text-secondary);
+  transform: scale(1.1);
 }
 
 .color-swatch.active {
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  outline-color: var(--accent);
+  box-shadow: 0 0 6px var(--accent-glow);
 }
 
-/* Icon picker */
+/* ============================================================
+   Icon Picker
+   ============================================================ */
+
 .icon-picker-trigger {
   display: flex;
   align-items: center;
@@ -347,39 +793,45 @@ button.small {
   grid-template-columns: repeat(8, 1fr);
   gap: 2px;
   padding: 8px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  max-height: 240px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  max-height: 260px;
   overflow-y: auto;
   position: absolute;
   z-index: 100;
   width: 320px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px var(--border-default);
+  margin-top: 4px;
 }
 
 .icon-picker-cell {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 4px;
-  border-radius: 4px;
+  padding: 5px 2px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 16px;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
 }
 
 .icon-picker-cell:hover {
   background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .icon-picker-cell.active {
   background: var(--accent);
-  color: white;
+  color: #0A0A0C;
 }
 
 .icon-picker-label {
-  font-size: 9px;
-  color: var(--text-dim);
-  margin-top: 2px;
+  font-size: 8px;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  margin-top: 3px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -387,11 +839,19 @@ button.small {
   text-align: center;
 }
 
-/* Add component dialog */
+.icon-picker-cell.active .icon-picker-label {
+  color: rgba(10, 10, 12, 0.7);
+}
+
+/* ============================================================
+   Add Component Dialog
+   ============================================================ */
+
 .add-dialog-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -399,64 +859,109 @@ button.small {
 }
 
 .add-dialog {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 16px;
-  min-width: 300px;
-  max-width: 400px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  min-width: 320px;
+  max-width: 420px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
 }
 
 .add-dialog h3 {
-  font-size: 15px;
-  margin-bottom: 12px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-dialog h3 i {
+  color: var(--accent);
+  font-size: 14px;
 }
 
 .add-dialog-group {
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--text-dim);
-  margin: 8px 0 4px;
+  color: var(--text-tertiary);
+  letter-spacing: 1px;
+  margin: 12px 0 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.add-dialog-group::before {
+  content: "";
+  width: 3px;
+  height: 10px;
+  background: var(--accent-muted);
+  border-radius: 1px;
 }
 
 .add-dialog-item {
-  padding: 6px 8px;
-  border-radius: 4px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+  border: 1px solid transparent;
 }
 
 .add-dialog-item:hover {
-  background: var(--bg-hover);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  border-color: rgba(232, 137, 60, 0.15);
 }
 
-/* Raw JSON editor */
+.add-dialog-footer {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ============================================================
+   Raw JSON Editor
+   ============================================================ */
+
 .json-editor {
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: 12px;
-  gap: 8px;
+  padding: 16px;
+  gap: 10px;
   overflow: hidden;
 }
 
 .json-editor textarea {
   flex: 1;
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 12px;
-  font-family: "SF Mono", "Fira Code", "JetBrains Mono", monospace;
-  font-size: 13px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 14px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
   resize: none;
   tab-size: 2;
+  transition: border-color var(--transition-fast);
 }
 
 .json-editor textarea:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-subtle);
 }
 
 .json-editor-actions {
@@ -467,39 +972,100 @@ button.small {
 
 .json-editor-error {
   color: var(--danger);
-  font-size: 12px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
-/* Status bar / error messages */
+/* ============================================================
+   Device Preview
+   ============================================================ */
+
+.device-preview-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.device-preview-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--text-tertiary);
+}
+
+.device-frame {
+  border: 2px solid var(--border-strong);
+  background: #09090b;
+  flex-shrink: 0;
+  box-shadow:
+    0 0 0 1px var(--border-subtle),
+    0 4px 16px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.device-frame.round {
+  border-radius: 50%;
+}
+
+.device-frame.rect {
+  border-radius: var(--radius-lg);
+}
+
+/* ============================================================
+   Error Banner
+   ============================================================ */
+
 .error-banner {
   padding: 8px 16px;
-  background: #7f1d1d;
+  background: var(--danger-subtle);
+  border-bottom: 1px solid rgba(229, 83, 75, 0.25);
   color: var(--danger);
-  font-size: 13px;
+  font-size: 12px;
+  font-family: var(--font-mono);
   display: flex;
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
 }
 
-.error-banner button {
-  margin-left: auto;
-}
-
-.empty-state {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: 1;
-  color: var(--text-dim);
+.error-banner i {
   font-size: 14px;
 }
 
-/* Dirty indicator */
-.dirty-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--accent);
-  display: inline-block;
+.error-banner button {
+  margin-left: auto;
+  font-size: 11px;
+}
+
+/* ============================================================
+   Empty State
+   ============================================================ */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  gap: 8px;
+  padding: 40px 20px;
+}
+
+.empty-state i {
+  font-size: 24px;
+  color: var(--border-strong);
+}
+
+.empty-state-text {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.3px;
 }

--- a/server/web/src/App.tsx
+++ b/server/web/src/App.tsx
@@ -64,8 +64,10 @@ export default function App() {
 
       {m.error && (
         <div className="error-banner">
+          <i className="fa fa-exclamation-triangle" />
           {m.error}
-          <button className="small" onClick={m.clearError}>
+          <button onClick={m.clearError}>
+            <i className="fa fa-times" style={{ fontSize: 10 }} />
             Dismiss
           </button>
         </div>
@@ -73,7 +75,8 @@ export default function App() {
 
       {!m.manifest ? (
         <div className="empty-state">
-          Select a board to start editing
+          <i className="fa fa-microchip" />
+          <span className="empty-state-text">Select a board to start editing</span>
         </div>
       ) : mode === "json" ? (
         <RawJsonEditor
@@ -96,43 +99,64 @@ export default function App() {
 
           <div className="editor-main">
             <div className="panel panel-left">
-              {screenRoot ? (
-                <ComponentTree
-                  root={screenRoot}
-                  selectedPath={m.selectedPath}
-                  schema={schema}
-                  onSelect={m.selectNode}
-                  onMove={m.moveNode}
-                  onRemove={m.removeNode}
-                  onAddChild={m.addChild}
-                />
-              ) : (
-                <div className="empty-state">No screen selected</div>
-              )}
-            </div>
-            <div className="panel panel-right">
-              {screenRoot && (
-                <div style={{ marginBottom: 16, display: "flex", justifyContent: "center" }}>
-                  <DevicePreview
+              <div className="panel-header">
+                <span className="panel-header-label">
+                  <i className="fa fa-sitemap" />
+                  Component Tree
+                </span>
+              </div>
+              <div className="panel-content">
+                {screenRoot ? (
+                  <ComponentTree
                     root={screenRoot}
                     selectedPath={m.selectedPath}
+                    schema={schema}
                     onSelect={m.selectNode}
-                    boardName={m.selectedBoard}
+                    onMove={m.moveNode}
+                    onRemove={m.removeNode}
+                    onAddChild={m.addChild}
                   />
-                </div>
-              )}
-              {selectedNode && schema ? (
-                <PropEditor
-                  node={selectedNode}
-                  schema={schema}
-                  onUpdateProps={m.updateNodeProps}
-                  onUpdateField={m.updateNodeField}
+                ) : (
+                  <div className="empty-state">
+                    <span className="empty-state-text">No screen selected</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="panel-center">
+              {screenRoot && (
+                <DevicePreview
+                  root={screenRoot}
+                  selectedPath={m.selectedPath}
+                  onSelect={m.selectNode}
+                  boardName={m.selectedBoard}
                 />
-              ) : (
-                <div className="empty-state">
-                  Select a component to edit its properties
-                </div>
               )}
+            </div>
+
+            <div className="panel panel-right">
+              <div className="panel-header">
+                <span className="panel-header-label">
+                  <i className="fa fa-sliders" />
+                  Properties
+                </span>
+              </div>
+              <div className="panel-content">
+                {selectedNode && schema ? (
+                  <PropEditor
+                    node={selectedNode}
+                    schema={schema}
+                    onUpdateProps={m.updateNodeProps}
+                    onUpdateField={m.updateNodeField}
+                  />
+                ) : (
+                  <div className="empty-state">
+                    <i className="fa fa-mouse-pointer" />
+                    <span className="empty-state-text">Select a component to edit</span>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </>

--- a/server/web/src/components/AddComponentDialog.tsx
+++ b/server/web/src/components/AddComponentDialog.tsx
@@ -13,7 +13,10 @@ export default function AddComponentDialog({ schema, onSelect, onClose }: Props)
   return (
     <div className="add-dialog-overlay" onClick={onClose}>
       <div className="add-dialog" onClick={(e) => e.stopPropagation()}>
-        <h3>Add Component</h3>
+        <h3>
+          <i className="fa fa-plus-circle" />
+          Add Component
+        </h3>
 
         <div className="add-dialog-group">Containers</div>
         {containers.map(([type]) => (
@@ -22,22 +25,24 @@ export default function AddComponentDialog({ schema, onSelect, onClose }: Props)
             className="add-dialog-item"
             onClick={() => onSelect(type)}
           >
+            <i className="fa fa-object-group" style={{ marginRight: 8, fontSize: 11, opacity: 0.5 }} />
             {type}
           </div>
         ))}
 
-        <div className="add-dialog-group">Leaves</div>
+        <div className="add-dialog-group">Components</div>
         {leaves.map(([type]) => (
           <div
             key={type}
             className="add-dialog-item"
             onClick={() => onSelect(type)}
           >
+            <i className="fa fa-cube" style={{ marginRight: 8, fontSize: 11, opacity: 0.5 }} />
             {type}
           </div>
         ))}
 
-        <div style={{ marginTop: 12, textAlign: "right" }}>
+        <div className="add-dialog-footer">
           <button onClick={onClose}>Cancel</button>
         </div>
       </div>

--- a/server/web/src/components/ColorPicker.tsx
+++ b/server/web/src/components/ColorPicker.tsx
@@ -6,7 +6,6 @@ interface Props {
 }
 
 function hexToNative(hex: string): string {
-  // "0xRRGGBB" -> "#RRGGBB"
   if (hex.startsWith("0x") || hex.startsWith("0X")) {
     return "#" + hex.slice(2).padStart(6, "0");
   }
@@ -14,7 +13,6 @@ function hexToNative(hex: string): string {
 }
 
 function nativeToHex(native: string): string {
-  // "#RRGGBB" -> "0xRRGGBB"
   return "0x" + native.slice(1).toUpperCase();
 }
 

--- a/server/web/src/components/DevicePreview.tsx
+++ b/server/web/src/components/DevicePreview.tsx
@@ -25,7 +25,7 @@ function PreviewNode({
     path.length === selectedPath.length &&
     path.every((v, i) => v === selectedPath[i]);
 
-  const outline = isSelected ? "2px solid #3b82f6" : "2px solid transparent";
+  const outline = isSelected ? "2px solid #E8893C" : "2px solid transparent";
 
   const renderChildren = () =>
     node.children?.map((child, i) => (
@@ -153,7 +153,6 @@ function PreviewNode({
     }
 
     case "Text": {
-      // Firmware sizes: 1=10pt, 2=12pt, 3=14pt, 4=18pt, 5=24pt
       const SIZES: Record<number, number> = { 1: 10, 2: 12, 3: 14, 4: 18, 5: 24 };
       const size = SIZES[Number(node.props?.size ?? 3)] ?? 14;
       return (
@@ -292,7 +291,6 @@ export default function DevicePreview({ root, selectedPath, onSelect, boardName 
   const isRound = boardName?.includes("makerfabs") || boardName?.includes("round");
   const isLarge = boardName?.includes("waveshare") || boardName?.includes("7");
 
-  // Render at native device resolution, then CSS scale down to fit
   const nativeW = isLarge ? 800 : 240;
   const nativeH = isLarge ? 480 : 240;
   const displayW = isLarge ? 280 : 160;
@@ -300,17 +298,13 @@ export default function DevicePreview({ root, selectedPath, onSelect, boardName 
   const displayH = nativeH * scale;
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
-      <div style={{ fontSize: 11, color: "#71717a" }}>Preview</div>
+    <div className="device-preview-wrapper">
+      <span className="device-preview-label">Preview</span>
       <div
+        className={`device-frame ${isRound ? "round" : "rect"}`}
         style={{
           width: displayW,
           height: displayH,
-          borderRadius: isRound ? "50%" : 8,
-          overflow: "hidden",
-          border: "2px solid #3f3f46",
-          background: "#09090b",
-          flexShrink: 0,
         }}
       >
         <div

--- a/server/web/src/components/Header.tsx
+++ b/server/web/src/components/Header.tsx
@@ -21,43 +21,60 @@ export default function Header({
 }: Props) {
   return (
     <div className="header">
-      <span className="header-title">round_touch</span>
+      <div className="header-brand">
+        <span className="header-logo" />
+        <span className="header-title">round_touch</span>
+      </div>
 
-      <select
-        value={selectedBoard ?? ""}
-        onChange={(e) => e.target.value && onSelectBoard(e.target.value)}
-      >
-        <option value="">Select board...</option>
-        {boards.map((b) => (
-          <option key={b.name} value={b.name}>
-            {b.name} ({b.screenCount} screens)
-          </option>
-        ))}
-      </select>
+      <div className="header-divider" />
+
+      <div className="board-select-wrapper">
+        <i className="fa fa-microchip" />
+        <select
+          className="board-select"
+          value={selectedBoard ?? ""}
+          onChange={(e) => e.target.value && onSelectBoard(e.target.value)}
+        >
+          <option value="">Select board...</option>
+          {boards.map((b) => (
+            <option key={b.name} value={b.name}>
+              {b.name} ({b.screenCount})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="header-spacer" />
 
       {selectedBoard && (
         <>
-          <button
-            className={mode === "tree" ? "active" : ""}
-            onClick={mode !== "tree" ? onToggleMode : undefined}
-          >
-            Tree
-          </button>
-          <button
-            className={mode === "json" ? "active" : ""}
-            onClick={mode !== "json" ? onToggleMode : undefined}
-          >
-            JSON
-          </button>
+          <div className="mode-toggle">
+            <button
+              className={`mode-toggle-btn${mode === "tree" ? " active" : ""}`}
+              onClick={mode !== "tree" ? onToggleMode : undefined}
+            >
+              <i className="fa fa-sitemap" style={{ fontSize: 10 }} />
+              Tree
+            </button>
+            <button
+              className={`mode-toggle-btn${mode === "json" ? " active" : ""}`}
+              onClick={mode !== "json" ? onToggleMode : undefined}
+            >
+              <i className="fa fa-code" style={{ fontSize: 10 }} />
+              JSON
+            </button>
+          </div>
+
+          {isDirty && <span className="dirty-dot" title="Unsaved changes" />}
 
           <button
-            className="primary"
+            className="save-btn"
             onClick={onSave}
             disabled={saving || !isDirty}
           >
+            <i className="fa fa-save" />
             {saving ? "Saving..." : "Save"}
           </button>
-          {isDirty && <span className="dirty-dot" title="Unsaved changes" />}
         </>
       )}
     </div>

--- a/server/web/src/components/IconPicker.tsx
+++ b/server/web/src/components/IconPicker.tsx
@@ -10,7 +10,6 @@ export default function IconPicker({ value, onChange }: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  // Close on outside click
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
@@ -34,11 +33,15 @@ export default function IconPicker({ value, onChange }: Props) {
           placeholder="Icon character"
           style={{ flex: 1 }}
         />
-        <button className="small" onClick={() => setOpen(!open)}>
+        <button
+          className="icon-btn"
+          onClick={() => setOpen(!open)}
+          style={{ width: 32, height: 32, border: "1px solid var(--border-default)" }}
+        >
           {currentSymbol ? (
-            <span className="tab-icon">{currentSymbol.code}</span>
+            <span className="tab-icon" style={{ fontSize: 14 }}>{currentSymbol.code}</span>
           ) : (
-            "Pick"
+            <i className="fa fa-th" />
           )}
         </button>
       </div>

--- a/server/web/src/components/PropEditor.tsx
+++ b/server/web/src/components/PropEditor.tsx
@@ -104,8 +104,11 @@ export default function PropEditor({
   if (!cs) {
     return (
       <div className="prop-editor">
-        <h3>{node.type}</h3>
-        <div style={{ color: "var(--text-dim)" }}>Unknown component type</div>
+        <div className="prop-editor-title">
+          <i className="fa fa-cube" />
+          {node.type}
+        </div>
+        <div className="prop-no-props">Unknown component type</div>
       </div>
     );
   }
@@ -115,7 +118,10 @@ export default function PropEditor({
 
   return (
     <div className="prop-editor">
-      <h3>{node.type}</h3>
+      <div className="prop-editor-title">
+        <i className="fa fa-cube" />
+        {node.type}
+      </div>
 
       {fieldEntries.length > 0 && (
         <>
@@ -146,7 +152,7 @@ export default function PropEditor({
       )}
 
       {fieldEntries.length === 0 && propEntries.length === 0 && (
-        <div style={{ color: "var(--text-dim)" }}>No editable properties</div>
+        <div className="prop-no-props">No editable properties</div>
       )}
     </div>
   );

--- a/server/web/src/components/RawJsonEditor.tsx
+++ b/server/web/src/components/RawJsonEditor.tsx
@@ -11,7 +11,6 @@ export default function RawJsonEditor({ manifest, onApply }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [localDirty, setLocalDirty] = useState(false);
 
-  // Sync from manifest when it changes externally
   useEffect(() => {
     setText(JSON.stringify(manifest, null, 2));
     setError(null);
@@ -21,7 +20,6 @@ export default function RawJsonEditor({ manifest, onApply }: Props) {
   const handleApply = () => {
     try {
       const parsed = JSON.parse(text);
-      // Basic structural check
       if (!parsed.version || !parsed.tabs || !parsed.screens) {
         setError("Missing required keys: version, tabs, screens");
         return;
@@ -56,15 +54,24 @@ export default function RawJsonEditor({ manifest, onApply }: Props) {
         spellCheck={false}
       />
       <div className="json-editor-actions">
-        <button onClick={handleFormat}>Format</button>
+        <button onClick={handleFormat}>
+          <i className="fa fa-indent" style={{ fontSize: 11 }} />
+          Format
+        </button>
         <button
           className="primary"
           onClick={handleApply}
           disabled={!localDirty}
         >
+          <i className="fa fa-check" style={{ fontSize: 11 }} />
           Apply to Editor
         </button>
-        {error && <span className="json-editor-error">{error}</span>}
+        {error && (
+          <span className="json-editor-error">
+            <i className="fa fa-exclamation-triangle" />
+            {error}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/server/web/src/components/TabManager.tsx
+++ b/server/web/src/components/TabManager.tsx
@@ -66,12 +66,15 @@ export default function TabManager({
                 onClick={(e) => e.stopPropagation()}
                 style={{
                   width: "80px",
-                  background: "var(--bg)",
+                  background: "var(--bg-input)",
                   border: "1px solid var(--accent)",
-                  borderRadius: "3px",
-                  color: "var(--text)",
-                  padding: "1px 4px",
-                  fontSize: "13px",
+                  borderRadius: "var(--radius-sm)",
+                  color: "var(--text-primary)",
+                  padding: "1px 6px",
+                  fontSize: "12px",
+                  fontFamily: "var(--font-sans)",
+                  outline: "none",
+                  boxShadow: "0 0 0 2px var(--accent-subtle)",
                 }}
               />
             ) : (
@@ -81,32 +84,32 @@ export default function TabManager({
             {isActive && (
               <div className="tab-actions" onClick={(e) => e.stopPropagation()}>
                 {i > 0 && (
-                  <button className="small" onClick={() => onReorder(i, i - 1)} title="Move left">
-                    &lt;
+                  <button className="icon-btn" onClick={() => onReorder(i, i - 1)} title="Move left">
+                    <i className="fa fa-chevron-left" />
                   </button>
                 )}
                 {i < tabs.length - 1 && (
-                  <button className="small" onClick={() => onReorder(i, i + 1)} title="Move right">
-                    &gt;
+                  <button className="icon-btn" onClick={() => onReorder(i, i + 1)} title="Move right">
+                    <i className="fa fa-chevron-right" />
                   </button>
                 )}
-                <button className="small" onClick={() => startEdit(tab)} title="Rename">
-                  ~
+                <button className="icon-btn" onClick={() => startEdit(tab)} title="Rename">
+                  <i className="fa fa-pencil" />
                 </button>
                 {!isDefault && (
-                  <button className="small" onClick={() => onSetDefault(tab.id)} title="Set as default">
-                    *
+                  <button className="icon-btn" onClick={() => onSetDefault(tab.id)} title="Set as default">
+                    <i className="fa fa-star-o" />
                   </button>
                 )}
                 {tabs.length > 1 && (
                   <button
-                    className="small danger"
+                    className="icon-btn danger"
                     onClick={() => {
                       if (confirm(`Delete tab "${tab.label}"?`)) onRemove(tab.id);
                     }}
                     title="Delete tab"
                   >
-                    x
+                    <i className="fa fa-trash-o" />
                   </button>
                 )}
               </div>
@@ -116,11 +119,11 @@ export default function TabManager({
       })}
 
       <button
-        className="small"
+        className="tab-add-btn"
         onClick={() => onAdd("\uF015", "New")}
         title="Add tab"
       >
-        +
+        <i className="fa fa-plus" />
       </button>
     </div>
   );

--- a/server/web/src/components/TreeNode.tsx
+++ b/server/web/src/components/TreeNode.tsx
@@ -70,34 +70,34 @@ export default function TreeNode({
         <div className="tree-node-actions">
           {!isRoot && index > 0 && (
             <button
-              className="small"
+              className="icon-btn"
               onClick={(e) => { e.stopPropagation(); onMove(path, "up"); }}
               title="Move up"
             >
-              &#9650;
+              <i className="fa fa-arrow-up" />
             </button>
           )}
           {!isRoot && index < siblingCount - 1 && (
             <button
-              className="small"
+              className="icon-btn"
               onClick={(e) => { e.stopPropagation(); onMove(path, "down"); }}
               title="Move down"
             >
-              &#9660;
+              <i className="fa fa-arrow-down" />
             </button>
           )}
           {canHaveChildren && (
             <button
-              className="small"
+              className="icon-btn"
               onClick={(e) => { e.stopPropagation(); onAddChild(path); }}
               title="Add child"
             >
-              +
+              <i className="fa fa-plus" />
             </button>
           )}
           {!isRoot && (
             <button
-              className="small danger"
+              className="icon-btn danger"
               onClick={(e) => {
                 e.stopPropagation();
                 const childCount = node.children?.length ?? 0;
@@ -106,7 +106,7 @@ export default function TreeNode({
               }}
               title="Delete"
             >
-              x
+              <i className="fa fa-trash-o" />
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Replace generic dark theme with cohesive industrial enterprise aesthetic using warm amber accents, IBM Plex Mono typography, and deep layered charcoal backgrounds
- Upgrade all controls to use FontAwesome icon buttons, segmented toggles, focus glow rings, and hover transitions
- Restructure layout into three-panel design (Component Tree / Device Preview / Properties) with sticky panel headers

## Test plan
- [ ] Start backend + Vite dev server, select a board, verify header renders with amber logo dot, monospace title, microchip board selector, and segmented Tree/JSON toggle
- [ ] Verify tab manager shows FA icon action buttons (chevrons, pencil, star, trash) and dashed add button
- [ ] Select components in tree, verify amber selection highlight, indentation lines, and hover-reveal action buttons
- [ ] Open property editor, verify accent-bar section headers, monospace labels, and input focus glow
- [ ] Open Add Component dialog, verify backdrop blur, FA icons per item type, accent-bar category headers
- [ ] Test color picker swatches (hover scale, active glow) and icon picker dropdown (elevated shadow)
- [ ] Switch to JSON mode, verify monospace textarea with FA-icon Format/Apply buttons
- [ ] Check custom scrollbars appear on overflow panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)